### PR TITLE
feat: updated specimen resource

### DIFF
--- a/fhir/src/services/tcga/tcga.test.js
+++ b/fhir/src/services/tcga/tcga.test.js
@@ -108,10 +108,38 @@ describe('TCGA service tests', () => {
         specimens: [
           {
             id: '591e99ec-46f9-442d-ac20-745dccc8a52b',
+            meta: { profile: ['http://hl7.org/fhir/StructureDefinition/Specimen'] },
+            identifier: [
+              {
+                system: 'urn:tcga:sample-id',
+                value: 'TCGA-HNSC-591e99ec-46f9-442d-ac20-745dccc8a52b',
+              },
+              {
+                system: 'urn:tcga:subject-id',
+                value: 'TCGA-HNSC-291b069c-9dde-4e1e-8430-85146bc94338',
+              },
+            ],
+            subject: {
+              reference: '291b069c-9dde-4e1e-8430-85146bc94338',
+            },
             resourceType: 'Specimen',
           },
           {
             id: '5e4e1e21-8016-4e27-8f72-2411714203e8',
+            meta: { profile: ['http://hl7.org/fhir/StructureDefinition/Specimen'] },
+            identifier: [
+              {
+                system: 'urn:tcga:sample-id',
+                value: 'TCGA-HNSC-5e4e1e21-8016-4e27-8f72-2411714203e8',
+              },
+              {
+                system: 'urn:tcga:subject-id',
+                value: 'TCGA-HNSC-291b069c-9dde-4e1e-8430-85146bc94338',
+              },
+            ],
+            subject: {
+              reference: '291b069c-9dde-4e1e-8430-85146bc94338',
+            },
             resourceType: 'Specimen',
           },
         ],
@@ -222,10 +250,38 @@ describe('TCGA service tests', () => {
       specimens: [
         {
           id: '591e99ec-46f9-442d-ac20-745dccc8a52b',
+          meta: { profile: ['http://hl7.org/fhir/StructureDefinition/Specimen'] },
+          identifier: [
+            {
+              system: 'urn:tcga:sample-id',
+              value: 'TCGA-HNSC-591e99ec-46f9-442d-ac20-745dccc8a52b',
+            },
+            {
+              system: 'urn:tcga:subject-id',
+              value: 'TCGA-HNSC-291b069c-9dde-4e1e-8430-85146bc94338',
+            },
+          ],
+          subject: {
+            reference: '291b069c-9dde-4e1e-8430-85146bc94338',
+          },
           resourceType: 'Specimen',
         },
         {
           id: '5e4e1e21-8016-4e27-8f72-2411714203e8',
+          meta: { profile: ['http://hl7.org/fhir/StructureDefinition/Specimen'] },
+          identifier: [
+            {
+              system: 'urn:tcga:sample-id',
+              value: 'TCGA-HNSC-5e4e1e21-8016-4e27-8f72-2411714203e8',
+            },
+            {
+              system: 'urn:tcga:subject-id',
+              value: 'TCGA-HNSC-291b069c-9dde-4e1e-8430-85146bc94338',
+            },
+          ],
+          subject: {
+            reference: '291b069c-9dde-4e1e-8430-85146bc94338',
+          },
           resourceType: 'Specimen',
         },
       ],

--- a/fhir/src/services/tcga/translator.js
+++ b/fhir/src/services/tcga/translator.js
@@ -107,8 +107,24 @@ class Translator {
   }
 
   toSpecimen(biospecimen) {
+    const sample_id = `${biospecimen.project_short_name}-${biospecimen.sample_gdc_id}`;
+    const subject_id = `${biospecimen.project_short_name}-${biospecimen.case_gdc_id}`;
+
     return new Specimen({
       id: biospecimen.sample_gdc_id,
+      meta: {
+        profile: ['http://hl7.org/fhir/StructureDefinition/Specimen'],
+      },
+      identifier: [
+        { system: 'urn:tcga:sample-id', value: sample_id },
+        {
+          system: 'urn:tcga:subject-id',
+          value: subject_id,
+        },
+      ],
+      subject: {
+        reference: biospecimen.case_gdc_id,
+      },
     });
   }
 


### PR DESCRIPTION
** BROAD-64 **

> There are lots of fields available for Specimen (https://www.hl7.org/fhir/specimen.html). We should look at what fields are coming back from BigQuery and see if we can slot them into our resource.

_additional nodes_
- instead of changing the id and references of the resource, i used identifiers
- this should make it so that nothing breaks, but we are able to identify the resource relative to the AnVIL resource