### PR TITLE
Split Kubernetes deployments

### DIFF
--- a/.github/workflows/build-and-publish-to-gcr.anvil.yml
+++ b/.github/workflows/build-and-publish-to-gcr.anvil.yml
@@ -1,4 +1,4 @@
-name: FHIR - Build and Publish to GCR
+name: AnVIL - Build and Publish to GCR
 
 on:
   push:
@@ -9,7 +9,7 @@ env:
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
   PROJECT_ID: ${{ secrets.PROJECT_ID }}
-  IMAGE: fhir
+  IMAGE: anvil
   ORGANIZATION: broad
   REGISTRY_HOSTNAME: gcr.io
   TYPE: ${{ secrets.TYPE }}
@@ -21,9 +21,7 @@ env:
   TOKEN_URI: ${{ secrets.TOKEN_URI }}
   AUTH_PROVIDER_X509_CERT_URL: ${{ secrets.AUTH_PROVIDER_X509_CERT_URL }}
   CLIENT_X509_CERT_URL: ${{ secrets.CLIENT_X509_CERT_URL }}
-  URL: ${{ secrets.URL }}
-  TCGA_URL: ${{ secrets.TCGA_URL }}
-  ANVIL_URL: ${{ secrets.ANVIL_URL }}
+  MONGO_READ_CONNECTION_STRING: ${{ secrets.MONGO_READ_CONNECTION_STRING }}
 
 jobs:
   run-tests:
@@ -32,7 +30,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: fhir
+        working-directory: anvil-api
 
     strategy:
       matrix:
@@ -56,7 +54,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: fhir
+        working-directory: anvil-api
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -76,15 +74,17 @@ jobs:
       - name: Install Node Modules
         run: npm install
 
+      - name: Generate GCP Credentials
+        run: node ../scripts/create-gcp-cred-file.js
+
       - name: Generate env
-        run: node ../scripts/create-env-file.js TCGA_URL=${{ secrets.TCGA_URL }} ANVIL_URL=${{ secrets.ANVIL_URL }} URL=${{ secrets.URL }}
+        run: node ../scripts/create-env-file.js PORT=3002 PROJECT_ID=${{ secrets.PROJECT_ID }}
 
       - name: Build
         run: |
           export TAG=`echo $GITHUB_SHA | cut -c1-7`
           echo Building image "$REGISTRY_HOSTNAME"/"$PROJECT_ID"/"$ORGANIZATION"/"$IMAGE":"$TAG"
           docker build -t "$REGISTRY_HOSTNAME"/"$PROJECT_ID"/"$ORGANIZATION"/"$IMAGE":"$TAG" .
-
       - name: Publish
         run: |
           export TAG=`echo $GITHUB_SHA | cut -c1-7`

--- a/.github/workflows/build-and-publish-to-gcr.anvil.yml
+++ b/.github/workflows/build-and-publish-to-gcr.anvil.yml
@@ -78,7 +78,7 @@ jobs:
         run: node ../scripts/create-gcp-cred-file.js
 
       - name: Generate env
-        run: node ../scripts/create-env-file.js PORT=3002 PROJECT_ID=${{ secrets.PROJECT_ID }}
+        run: node ../scripts/create-env-file.js PORT=3002 MONGO_CONNECTION_STRING=${{ secrets.MONGO_READ_CONNECTION_STRING }} PROJECT_ID=${{ secrets.PROJECT_ID }}
 
       - name: Build
         run: |

--- a/anvil-api/Dockerfile
+++ b/anvil-api/Dockerfile
@@ -8,6 +8,6 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 3002
 
 CMD [ "npm", "start" ]

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -58,7 +58,9 @@ kubectl set image deployments/fhir app=gcr.io/${PROJECT_ID}/broad/fhir:$(git log
 ## Deploy the K8 Spec file and monitor the deployment
 
 ```
-kubectl apply -f deployment.yml && kubectl rollout status deployment/broad-fhir-deployment
+kubectl apply -f fhir-deployment.yml && kubectl rollout status deployment/broad-fhir-deployment
+kubectl apply -f anvil-deployment.yml && kubectl rollout status deployment/broad-anvil-deployment
+kubectl apply -f tcga-deployment.yml && kubectl rollout status deployment/broad-tcga-deployment
 ```
 
 ## Common issues

--- a/kube/deployments/anvil-deployment.yml
+++ b/kube/deployments/anvil-deployment.yml
@@ -28,6 +28,7 @@ spec:
     spec:
       containers:
         - name: anvil
-          image: gcr.io/broad-fhir-dev/broad/anvil:5f102a9
+          image: gcr.io/broad-fhir-dev/broad/anvil:79168f5
           ports:
             - containerPort: 3002
+          imagePullPolicy: Always

--- a/kube/deployments/anvil-deployment.yml
+++ b/kube/deployments/anvil-deployment.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: broad-anvil-svc
+spec:
+  selector:
+    app: broad-anvil-deployment
+  ports:
+    - port: 3002
+      targetPort: 3002
+      protocol: TCP
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: broad-anvil-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: broad-anvil-deployment
+  template:
+    metadata:
+      labels:
+        app: broad-anvil-deployment
+    spec:
+      containers:
+        - name: anvil
+          image: gcr.io/broad-fhir-dev/broad/anvil:5f102a9
+          ports:
+            - containerPort: 3002

--- a/kube/deployments/fhir-deployment.yml
+++ b/kube/deployments/fhir-deployment.yml
@@ -28,21 +28,14 @@ spec:
     spec:
       containers:
         - name: fhir
-          image: gcr.io/broad-fhir-dev/broad/fhir:422d7b3
+          image: gcr.io/broad-fhir-dev/broad/fhir:5f102a9
           ports:
             - containerPort: 3000
           env:
             - name: TCGA_URL
-              value: http://localhost:3001
+              value: http://broad-tcga-svc.default.svc.cluster.local:3001
             - name: ANVIL_URL
-              value: http://localhost:3002
+              value: http://broad-anvil-svc.default.svc.cluster.local:3002
+            - name: URL
+              value: https://fhir.dev.envs-terra.bio/4_0_0/
           imagePullPolicy: Always
-        - name: tcga
-          image: gcr.io/broad-fhir-dev/broad/tcga:422d7b3
-          ports:
-            - containerPort: 3001
-          imagePullPolicy: Always
-        - name: anvil
-          image: gcr.io/broad-fhir-dev/broad/anvil:422d7b3
-          ports:
-            - containerPort: 3002

--- a/kube/deployments/fhir-deployment.yml
+++ b/kube/deployments/fhir-deployment.yml
@@ -31,11 +31,4 @@ spec:
           image: gcr.io/broad-fhir-dev/broad/fhir:5f102a9
           ports:
             - containerPort: 3000
-          env:
-            - name: TCGA_URL
-              value: http://broad-tcga-svc.default.svc.cluster.local:3001
-            - name: ANVIL_URL
-              value: http://broad-anvil-svc.default.svc.cluster.local:3002
-            - name: URL
-              value: https://fhir.dev.envs-terra.bio/4_0_0/
           imagePullPolicy: Always

--- a/kube/deployments/tcga-deployment.yml
+++ b/kube/deployments/tcga-deployment.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: broad-tcga-svc
+spec:
+  selector:
+    app: broad-tcga-deployment
+  ports:
+    - port: 3001
+      targetPort: 3001
+      protocol: TCP
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: broad-tcga-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: broad-tcga-deployment
+  template:
+    metadata:
+      labels:
+        app: broad-tcga-deployment
+    spec:
+      containers:
+        - name: tcga
+          image: gcr.io/broad-fhir-dev/broad/tcga:5f102a9
+          ports:
+            - containerPort: 3001

--- a/kube/deployments/tcga-deployment.yml
+++ b/kube/deployments/tcga-deployment.yml
@@ -28,6 +28,7 @@ spec:
     spec:
       containers:
         - name: tcga
-          image: gcr.io/broad-fhir-dev/broad/tcga:5f102a9
+          image: gcr.io/broad-fhir-dev/broad/tcga:3bf0b64
           ports:
             - containerPort: 3001
+          imagePullPolicy: Always

--- a/tcga/Dockerfile
+++ b/tcga/Dockerfile
@@ -8,6 +8,6 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 3001
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
## Summary
> _summary of changes_
Split out the api deployments into 3 different deployments instead of one. This allows them to deploy into seperate pods/nodes.
- - -

_changelog_
- _added_
- _removed_
- _updated_

_additional notes_
- _notes here_
